### PR TITLE
e310_sg3 fails

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -13,7 +13,7 @@
     <project name="bitbake"  remote="openembedded" path="bitbake" revision="79e62eef1c93f742bf71e9f25db57fdd2ffedd02" />
 
     <!-- branch thud -->
-    <project name="meta-ettus" remote="ettus" path="meta-ettus" revision="d60bfe6a96f6ed788d503a5f6b442ec6cf13f507" />
+    <project name="meta-ettus" remote="ettus" path="meta-ettus" revision="434d1b54c62877f169c2a48c9fb97fa20ea4d1bf" />
 
     <!-- branch thud -->
     <project name="meta-mender" remote="mender" path="meta-mender" revision="761a4c5277decb80154ca239745b40a206ffc05e" />


### PR DESCRIPTION
Build fails with the fixed commit previously when building for e310's as the setup_build_env has the correct configuration whereas the meta-e31x .bbappend does not provide the needed firmware and image packages. Recent commit does and fixes this build issue.